### PR TITLE
Fix #33

### DIFF
--- a/main.py
+++ b/main.py
@@ -318,7 +318,7 @@ def run(play):
                 play = 0
                 return play
             elif quit.lower().startswith('g'):
-                map_location = 1
+                map_location = search(0, 0)
                 player["x"] = 0
                 player["y"] = 0
         print(" ")


### PR DESCRIPTION
The error happens because you set the map_location to 1 but it's actually 0 for x:0,y:0. I set the new map_location to `search(0, 0)`, as it's not sure that the `point0` map point's coordinates are x:0,y:0. For example in Bane Of Wargs, since the map is generated, `point0` is x:-64,y:64.

Fixes #33.